### PR TITLE
fix: half-working version of audio read buffer faster

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -72,7 +72,7 @@ const RenderListItem = React.memo(
     };
 
     useEffect(() => {
-      if(Platform.OS === 'android') AudioWaveform.enableRateLimiting(2);
+      // if(Platform.OS === 'android') AudioWaveform.enableRateLimiting(2);
     });
 
 


### PR DESCRIPTION
Changes taken from [this post](https://imnotyourson.com/enhance-poor-performance-of-decoding-audio-with-mediaextractor-and-mediacodec-to-pcm/) to increase the reading of audio file